### PR TITLE
Add physio as a datatype

### DIFF
--- a/src/schema/objects/datatypes.yaml
+++ b/src/schema/objects/datatypes.yaml
@@ -68,6 +68,11 @@ phenotype:
     Participant level measurement data
     (for example, responses from multiple questionnaires)
     split into individual files separate from `participants.tsv`.
+physio:
+  value: physio
+  display_name: Physiological Data
+  description: |
+    Continuous peripheral physiological recordings such as respiratory, cardiac, pulse, gastric fluctuations, skin conductance, or blood pressure changes.
 nirs:
   value: nirs
   display_name: Near-Infrared Spectroscopy


### PR DESCRIPTION
Here I added a brief physio entry to the datatypes.yaml list (c.f. #12 )

Potentially the wording of this entry should be adjusted in the future to better clarify our relationship to the EMG BEP. I'm also not sure if a corresponding change should be made to modalities.yaml, I'm having trouble finding where the latter table is used by the compiler macros.