### PR TITLE
Adding metadata from BEP document to specification glossary

### DIFF
--- a/src/schema/objects/enums.yaml
+++ b/src/schema/objects/enums.yaml
@@ -1441,3 +1441,73 @@ PhysioTypeEnriched:
   display_name: Enriched Physiological Recording
   description: |
     Physiological recording data accompanied by enriched metadata.
+PPG__physio:
+  value: PPG
+  display_name: Photoplethysmography (PPG)
+  tags:
+    - physio
+  description: |
+    Continuous optical measurements capturing cardiac pulsation.
+Trigger:
+  value: Trigger
+  display_name: Trigger
+  tags:
+    - physio
+  description: |
+    Continuous digital (binary TTL) or analog (TTL in Volt) values indicating scanner triggers.
+ECG__physio:
+  value: ECG
+  display_name: Electrocardiogram (ECG)
+  tags:
+    - physio
+  description: |
+    Continuous electrical measurements capturing cardiac activity.
+Ventilation:
+  value: Ventilation
+  display_name: Ventilation
+  tags:
+    - physio
+  description: |
+    Continuous breathing measurements, e.g. signal acquired using a respiratory belt.
+CO2:
+  value: CO2
+  display_name: Carbon dioxide (CO2)
+  tags:
+    - physio
+  description: |
+    Continuous measurements of the carbon dioxide concentration in expired air..
+O2:
+  value: O2
+  display_name: Oxygen (O2)
+  tags:
+    - physio
+  description: |
+    Continuous measurements of the oxygen concentration from respiratory gases.
+PETCO2:
+  value: PETCO2
+  display_name: End-tidal carbon dioxide (PETCO2)
+  tags:
+    - physio
+  description: |
+    Continuous measurements of the end-tidal pressure of carbon dioxide at the end of an exhalation.
+PETO2:
+  value: PETO2
+  display_name: End-tidal oxygen (PETO2)
+  tags:
+    - physio
+  description: |
+    Continuous measurements of the end-tidal pressure of oxygen at the end of an inhalation.
+EDA:
+  value: EDA
+  display_name: Electrodermal activity (EDA)
+  tags:
+    - physio
+  description: |
+    Continuous measurements of changes in the electrical properties of the skin.
+BP:
+  value: BP
+  display_name: Blood pressure (BP)
+  tags:
+    - physio
+  description: |
+    Continuous measurements of the blood pressure waveform representing changes in arterial pressure over time.

--- a/src/schema/objects/metadata.yaml
+++ b/src/schema/objects/metadata.yaml
@@ -2211,19 +2211,17 @@ MeasureType:
     Describes the category of physiological data which was recorded.
   type: string
   enum:
-  - Trigger, 
-  - PPG 
-  - ECG 
-  - Ventilation
-  - CO2
-  - O2
-  - PetCO2
-  - PetO2
-  - EDA-tonic
-  - EDA-phasic
-  - EDA-total
-  - BP 
-  - Other
+    - $ref: objects.enums.BP.value
+    - $ref: objects.enums.PPG__physio.value
+    - $ref: objects.enums.ECG__physio.value
+    - $ref: objects.enums.Ventilation.value
+    - $ref: objects.enums.EDA.value
+    - $ref: objects.enums.CO2.value
+    - $ref: objects.enums.O2.value
+    - $ref: objects.enums.PETCO2.value
+    - $ref: objects.enums.PETO2.value
+    - $ref: objects.enums.Trigger.value
+    - Other
 MetaboliteAvail:
   name: MetaboliteAvail
   display_name: Metabolite Available


### PR DESCRIPTION
Some checks on formatting (particularly for how I entered the allowable values) might be necessary here, I also added some new comments on the BEP document to flag potential issues or changes we could make going forward.

This should allow our metadata fields to be referenced when creating the appropriate macro templates! 

After much discussion in our monthly meetings, I believe this closes #21 and also resolves #4.